### PR TITLE
fix bug: CreateGraphicsResources always return S_OK

### DIFF
--- a/Platform/Windows/helloengine_d3d.cpp
+++ b/Platform/Windows/helloengine_d3d.cpp
@@ -169,8 +169,6 @@ HRESULT CreateGraphicsResources(HWND hWnd)
                                                     D3D_FEATURE_LEVEL_9_1};
         D3D_FEATURE_LEVEL FeatureLevelSupported;
 
-        HRESULT hr = S_OK;
-
         // create a device, device context and swap chain using the information in the scd struct
         hr = D3D11CreateDeviceAndSwapChain(NULL,
                                       D3D_DRIVER_TYPE_HARDWARE,


### PR DESCRIPTION
The declaration of the HRESULT of the inner block overrides the outer one, this makes function CreateGraphicsResources always return S_OK